### PR TITLE
Expanded ability for setting field data

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,15 @@ waterwheel.api.user.delete(1)
 
 ```javascript
 waterwheel.populateResources()
-  .then(() => waterwheel.api.node.page.setField(1, 'title', 'my favorite title'))
+  .then(() => waterwheel.api.node.page.setField(1, {title: 'my favorite title'})) // Set a single value
+  .then(() => waterwheel.api.node.page.setField(1, [ // Set multiple values
+    {title: 'my favorite title'},
+    {email: ['a@aaa.com', 'b@bbb.com', 'c@ccc.com']}
+  ]))
+  .then(() => waterwheel.api.node.page.setField(1, [ // Pass additional message body data.
+    {title: 'my favorite title'},
+    {email: ['a@aaa.com', 'b@bbb.com', 'c@ccc.com']}
+  ], {body: [{value: 'foo'}]} ))
   .then(res => {
     // Data sent to Drupal
   })
@@ -207,8 +215,10 @@ waterwheel.populateResources()
 
 `.setField()` accepts 3 arguments
   - `identifier`: The id of the entity you are setting field values on
-  - `fieldName`: The name of the field you are attempting to set the value of.
-  - `fieldValue`: The value of the field. Either a string of a single value, or an array for multi-value.
+  - `fields`: Fields and values to be set on the entity.
+    - A single object can be passed, `{title: 'my favorite title'}`
+    - An array of objects can be passed, `[{title: 'my favorite title'}, {subtitle: 'my favorite sub title'}]`
+  - `additionalValues`: An object of fields (the objects keys), and values that are copied to the body data prior to the `PATCH` request. **Be aware that this happens last and could overwrite any previously set fields.**
 
 ### Get field metadata for an entity/bundle
 

--- a/lib/entity.js
+++ b/lib/entity.js
@@ -89,35 +89,52 @@ module.exports = class Entity extends Request {
    * Set a field on a specific entity
    * @param  {string|number} identifier
    *   The entity we are setting the field on.
-   * @param  {string} field
+   * @param  {object[]|object} fields
    *   The field name we are setting the data on.
-   * @param  {string|array|object} value
-   *   The value(s) that are being set.
+   * @param  {object} additionalValues
+   *   Any additional values to be appended to the post body.
    * @return  {Promise}
    *   The resolved promise.
    */
-  setField(identifier, field, value) {
+  setField(identifier, fields, additionalValues) {
     return new Promise((resolve, reject) => {
       (!this.metadata.fields
         ? this.getFieldData()
         : Promise.resolve())
       .then(() => {
-        if (!Object.keys(this.metadata.fields).includes(field)) {
-          return reject(`The field, ${field}, is not included on, ${this.bundle}.`);
+
+        const availableFieldKeys = Object.keys(this.metadata.fields);
+        const nonMatchedFields = (Array.isArray(fields) ? fields : [fields])
+          .map(field => (Object.keys(field)[0]))
+          .map(fieldKey => {
+            if (!availableFieldKeys.includes(fieldKey)) {
+              return fieldKey;
+            }
+            return false;
+          }).filter(Boolean);
+
+        if (nonMatchedFields.length){
+          return reject(new Error(`The ${nonMatchedFields.length > 1 ? 'fields' : 'field'}, ${nonMatchedFields.join(', ')}, ${nonMatchedFields.length > 1 ? 'are' : 'is'} not included within the bundle, ${this.bundle}.`));
         }
-        const fieldDetails = this.metadata.fields[field];
         const bodyContent = {type: this.bundle};
 
-        if (typeof value === 'string') {
-          bodyContent[field] = [{value: value}];
-        }
+        (Array.isArray(fields) ? fields : [fields]).forEach(field => {
+          const fK = Object.keys(field)[0];
+          const fV = field[fK];
 
-        if (Array.isArray(value)) {
-          bodyContent[field] = value.map(i => ({value: i}));
-        }
+          if (typeof fV === 'string') {
+            bodyContent[fK] = [{value: fV}];
+          }
+          if (Array.isArray(fV)) {
+            bodyContent[fK] = fV.map(i => ({value: i}));
+          }
+        });
 
-        else {
-          bodyContent[field] = value;
+        // Be aware, this is direct copy and will overwrite previously set values.
+        if (additionalValues && Object.keys(additionalValues).length !== 0) {
+          Object.keys(additionalValues).forEach(key => {
+            bodyContent[key] = additionalValues[key];
+          });
         }
 
         return this.patch(identifier, bodyContent)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,11 +19,7 @@ module.exports = {
       {
         test: /\.js?$/,
         exclude: /node_modules/,
-        loader: 'babel',
-        query: {
-          presets: ['es2015'],
-          cacheDirectory: true
-        }
+        loaders: ['babel?presets[]=es2015']
       },
       {
         test: /\.json?$/,


### PR DESCRIPTION
![](https://media.giphy.com/media/bqNwwuxz661Vu/giphy.gif)
#### Features
- Expanded the ability to set multiple fields in a single request.
- Included the ability to reject the `setField()` action when trying to set a field that is not part of the `bundle`.
- Adjustments to testing and documentation.
#### Fixes
- Fixes an issue with exporting `Waterwheel` to the browser environment. Regression from 7a88ebf84837a9da80595ac0c271306731945b5c
