### PR TITLE
Correct nomenclature of Hydrant to Waterwheel in 0.5.0

### DIFF
--- a/lib/waterwheel.js
+++ b/lib/waterwheel.js
@@ -80,7 +80,7 @@ module.exports = class Waterwheel extends Request {
   }
 
   /**
-   * Populate hydrant.api with available resources from Drupal.
+   * Populate Waterwheel.api with available resources from Drupal.
    * @param  {string} [format=json]
    *   The format to request the types in.
    *   @TODO: Support the processing of a response in a format besides JSON.


### PR DESCRIPTION
Applying @steveoliver's fix (#15) to the `0.5.0` branch, which will be merged into `master` once the 0.5.0 milestone is reached.
