### PR TITLE
Use postinstall to provide compiled lib for browser

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+coverage
+.nyc_output
+test/server/js/waterwheel.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-coverage
-.nyc_output
-test/server/js/waterwheel.js

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ const Waterwheel = require('waterwheel');
 const waterwheel = new Waterwheel('http://test.dev', {username: 'admin', 'password': '1234'});
 
 // Browser
+import '../../path/to/node_modules/waterwheel/dist/waterwheel.js'
 const waterwheel = new window.Waterwheel('http://test.dev', {username: 'admin', 'password': '1234'});
+// Or use Webpack's ProvidePlugin to expose Waterwheel globally.
 ```
 
 Waterwheel when instantiated accepts two arguments

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ const waterwheel = new Waterwheel('http://test.dev', {username: 'admin', 'passwo
 // Browser
 import '../../path/to/node_modules/waterwheel/dist/waterwheel.js'
 const waterwheel = new window.Waterwheel('http://test.dev', {username: 'admin', 'password': '1234'});
-// Or use Webpack's ProvidePlugin to expose Waterwheel globally.
 ```
 
 Waterwheel when instantiated accepts two arguments

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "nyc --reporter=html ava -v && nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
-    "prepublish": "npm run build"
+    "postinstall": "npm run build"
   },
   "keywords": [
     "drupal",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "webpack --progress",
     "test": "nyc --reporter=html ava -v && nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prepublish": "npm run build"
   },
   "keywords": [
     "drupal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [


### PR DESCRIPTION
Npm provides a `prepublish` script that allows commands to be run before publishing and upon a local `npm i`. I suggest adding the `build` command so that browser users can import `dist/waterwheel.js` without requiring the manual `npm run build`. `.npmignore` is required since `dist/waterwheel.js` is explicitly ignored in `.gitignore` (which `prepublish` falls back to).
## Test
- Use `npm i waterwheel` to test this. Make sure a dist dir with a successfully compiled `waterwheel.js` exists in `node_modules/waterwheel/`
