### PR TITLE
Pass format parameter as Content-type header for .patch()

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -40,9 +40,9 @@ module.exports = class Entity extends Request {
    *  The format for the requested content.
    * @returns {Promise} A Promise that when fulfilled returns a response containing the content entity in JSON (as of 8.2).
    */
-  patch(identifier, body = {}, format = 'json') {
+  patch(identifier, body = {}, format = 'application/json') {
     return this.getXCSRFToken()
-      .then((csrfToken) => this.issueRequest(methods.patch, `${this.paths.PATCH.replace(this.paths.GET.match(/\{.*?\}/), identifier)}?_format=${format}`, csrfToken, {}, body));
+      .then((csrfToken) => this.issueRequest(methods.patch, `${this.paths.PATCH.replace(this.paths.GET.match(/\{.*?\}/), identifier)}`, csrfToken, {'Content-type': format}, body));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [


### PR DESCRIPTION
I was getting a 405 on `.patch()` and upon [some digging](https://www.drupal.org/node/2659070) found that this was a actually just a poor response code for what was actually happening, expecting a Content-type header. That response code will be fixed in 8.2 by sending back a 415, but Waterwheel should send the expected headers for PATCH requests regardless.
