### PR TITLE
Prepublish build

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+coverage
+.nyc_output
+test/server/js/waterwheel.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "nyc --reporter=html ava -v && nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "lint": "eslint .",
-    "postinstall": "npm run build"
+    "prepublish": "npm run build"
   },
   "keywords": [
     "drupal",


### PR DESCRIPTION
Turns out acquia/waterwheel/pull/21 with `prepublish` was the right approach after all. 

From acquia/waterwheel/pull/21

> Npm provides a prepublish script that allows commands to be run before publishing and upon a local npm i. I suggest adding the build command so that browser users can import dist/waterwheel.js without requiring the manual npm run build. .npmignore is required since dist/waterwheel.js is explicitly ignored in .gitignore (which prepublish falls back to).

Addresses acquia/waterwheel/issues/27
