### PR TITLE
Update Axios version to 0.13.1

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -59,8 +59,8 @@ module.exports = class Request extends Base {
       this.axios(options)
         .then(res => resolve(res.data))
         .catch(err => {
-          const error = new Error(err.data.message);
-          error.status = err.status;
+          const error = new Error(err.response.data.message || 'Unknown error.');
+          error.status = err.response.status;
           return reject(error);
         });
     });

--- a/package.json
+++ b/package.json
@@ -26,21 +26,21 @@
     "waterwheel"
   ],
   "dependencies": {
-    "axios": "^0.13.1"
+    "axios": "0.13.1"
   },
   "devDependencies": {
-    "ava": "^0.15.1",
-    "babel-core": "^6.8.0",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
-    "browserify": "^13.0.0",
-    "coveralls": "^2.11.9",
-    "eslint": "^2.9.0",
-    "expose-loader": "^0.7.1",
-    "nightmare": "^2.5.2",
-    "nyc": "^6.4.4",
-    "require-subvert": "^0.1.0",
-    "webpack": "^1.13.0"
+    "ava": "0.16.0",
+    "babel-core": "6.8.0",
+    "babel-loader": "6.2.4",
+    "babel-preset-es2015": "6.6.0",
+    "browserify": "13.0.0",
+    "coveralls": "2.11.9",
+    "eslint": "2.9.0",
+    "expose-loader": "0.7.1",
+    "nightmare": "2.6.1",
+    "nyc": "6.4.4",
+    "require-subvert": "0.1.0",
+    "webpack": "1.13.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "waterwheel"
   ],
   "dependencies": {
-    "axios": "^0.11.0"
+    "axios": "^0.13.1"
   },
   "devDependencies": {
     "ava": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [

--- a/test/request.js
+++ b/test/request.js
@@ -29,7 +29,14 @@ test.cb('Request Failure', t => {
   t.plan(3);
 
   requireSubvert.subvert('axios', () => (
-    Promise.reject({data: {message: 'bar'}, status: 404})
+    Promise.reject({
+      response: {
+        data: {
+          message: 'bar'
+        },
+        status: 404
+      }
+    })
   ));
 
   const Request = requireSubvert.require('../lib/helpers/request');
@@ -40,6 +47,29 @@ test.cb('Request Failure', t => {
       t.is(true, err instanceof Error, 'Unxpected response.');
       t.is(404, err.status, 'Unxpected response.');
       t.is('bar', err.message, 'Unxpected response.');
+      t.end();
+    });
+});
+test.cb('Request Failure - No message', t => {
+  t.plan(3);
+
+  requireSubvert.subvert('axios', () => (
+    Promise.reject({
+      response: {
+        data: {},
+        status: 404
+      }
+    })
+  ));
+
+  const Request = requireSubvert.require('../lib/helpers/request');
+  const request = new Request('http://foo.dev', {user: 'a', pass: 'b'});
+
+  request.issueRequest('GET', '/entity/1', '12345')
+    .catch(err => {
+      t.is(true, err instanceof Error, 'Unxpected response.');
+      t.is(404, err.status, 'Unxpected response.');
+      t.is('Unknown error.', err.message, 'Unxpected response.');
       t.end();
     });
 });


### PR DESCRIPTION
Updated Axios version to 0.13.1. To test, `npm i` to grab the new dependency from NPM, and `npm t` to make sure that all tests still pass on the new version of Axios.
