### PR TITLE
Fix content type header casing - third time lucky

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -42,7 +42,7 @@ module.exports = class Entity extends Request {
    */
   patch(identifier, body = {}, format = 'application/json') {
     return this.getXCSRFToken()
-      .then((csrfToken) => this.issueRequest(methods.patch, `${this.paths.PATCH.replace(this.paths.GET.match(/\{.*?\}/), identifier)}`, csrfToken, {'Content-type': format}, body));
+      .then((csrfToken) => this.issueRequest(methods.patch, `${this.paths.PATCH.replace(this.paths.GET.match(/\{.*?\}/), identifier)}`, csrfToken, {'Content-Type': format}, body));
   }
 
   /**
@@ -55,7 +55,7 @@ module.exports = class Entity extends Request {
    */
   post(body, format = 'application/json') {
     return this.getXCSRFToken()
-      .then((csrfToken) => this.issueRequest(methods.post, this.paths.POST, csrfToken, {'Content-type': format}, body));
+      .then((csrfToken) => this.issueRequest(methods.post, this.paths.POST, csrfToken, {'Content-Type': format}, body));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterwheel",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A generic JavaScript helper library to query and manipulate Drupal 8 via core REST",
   "author": "Preston So <preston.so@acquia.com>",
   "contributors": [


### PR DESCRIPTION
Hi,

Axios dependencies listed at 0.11. Prior to [this commit in axios project](https://github.com/mzabriskie/axios/commit/3c4dfe8a8112d685e0cdaf8d96c18e0258b8b129) header type 'Content-Type' is case sensitive as preceeding, but is currently set as 'Content-type'.

I noticed that the Content-Type request header value was being duplicated on 'POST' and 'PATCH' requests, like this: 'application/json, application/json' and this was causing my Drupal instance to fall over. This patch fixes that.

Suggest either updating the module or taking in this patch if appropriate.

Thanks,
Brendan.
