### PR TITLE
feat(JSONAPI): Add a prefix option for use with JSONAPI

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
     "ecmaVersion": 6,
     "sourceType": "module",
     "ecmaFeatures": {
-      "impliedStrict": true
+      "impliedStrict": true,
+      "experimentalObjectRestSpread": true
     }
   },
   "rules": {

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ When requesting embedded resources duplicates are removed to prevent extra HTTP 
 
 ### JSON API
 
-`waterwheel` contains provisional support for requesting data using the `json:api` format. Currently only `GET` requests are supported; this simplifies the instantiation of `waterwheel`.
+`waterwheel` contains provisional support for requesting data using the `json:api` format. A `prefix` option can be passed into the constructor to allow for older versions of the JSON API module, which used the `api` prefix in the URL, to be used. The `prefix` option defaults to `jsonapi` and in turn, builds a URL like the following example: `http://foo.dev/jsonapi/node/article?_format=api_json`.
 
 ```javascript
 const Waterwheel = require('waterwheel');

--- a/lib/jsonapi.js
+++ b/lib/jsonapi.js
@@ -6,6 +6,7 @@ const qs = require('qs');
 module.exports = class JSONAPI extends Request {
   constructor(options) {
     super(options);
+    this.prefix = options.prefix || 'jsonapi';
   }
 
   /**
@@ -22,7 +23,7 @@ module.exports = class JSONAPI extends Request {
  */
   get(resource, params, id = false) {
     const format = 'api_json';
-    const url = `/api/${resource}${id ? `/${id}` : ''}?_format=${format}${Object.keys(params).length ? `&${qs.stringify(params, {indices: false})}` : ''}`;
+    const url = `/${this.prefix}/${resource}${id ? `/${id}` : ''}?_format=${format}${Object.keys(params).length ? `&${qs.stringify(params, {indices: false})}` : ''}`;
     return this.issueRequest(methods.get, url, '');
   }
 
@@ -38,7 +39,7 @@ module.exports = class JSONAPI extends Request {
    */
   post(resource, body) {
     const format = 'api_json';
-    return this.issueRequest(methods.post, `/api/${resource}?_format=${format}`, '', {'Content-Type': 'application/vnd.api+json'}, body);
+    return this.issueRequest(methods.post, `/${this.prefix}/${resource}?_format=${format}`, '', {'Content-Type': 'application/vnd.api+json'}, body);
   }
 
 };

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -34,7 +34,7 @@ test('JSONAPI - Collections / Lists', t => {
   const jsonapi = new t.context.JSONAPI(t.context.options);
   return jsonapi.get('node/article', {})
     .then(res => {
-      t.is('http://foo.dev/api/node/article?_format=api_json', res.url);
+      t.is('http://foo.dev/jsonapi/node/article?_format=api_json', res.url);
     });
 });
 
@@ -45,7 +45,7 @@ test('JSONAPI - Related resources', t => {
   const jsonapi = new t.context.JSONAPI(t.context.options);
   return jsonapi.get('node/article', {}, 'cc1b95c7-1758-4833-89f2-7053ae8e7906/uid')
     .then(res => {
-      t.is('http://foo.dev/api/node/article/cc1b95c7-1758-4833-89f2-7053ae8e7906/uid?_format=api_json', res.url);
+      t.is('http://foo.dev/jsonapi/node/article/cc1b95c7-1758-4833-89f2-7053ae8e7906/uid?_format=api_json', res.url);
     });
 });
 
@@ -62,7 +62,7 @@ test('JSONAPI - Filter basic', t => {
     }
   })
     .then(res => {
-      t.is('http://foo.dev/api/node/article?_format=api_json&filter%5Buuid%5D%5Bvalue%5D=563196f5-4432-4964-9aeb-e4d326cb1330', res.url);
+      t.is('http://foo.dev/jsonapi/node/article?_format=api_json&filter%5Buuid%5D%5Bvalue%5D=563196f5-4432-4964-9aeb-e4d326cb1330', res.url);
     });
 });
 
@@ -77,7 +77,7 @@ test('JSONAPI - Filter with operator', t => {
     }
   })
     .then(res => {
-      t.is('http://foo.dev/api/node/article?_format=api_json&filter%5Bcreated%5D%5Bvalue%5D=1469001416&filter%5Bcreated%5D%5Boperator%5D=%3D', res.url);
+      t.is('http://foo.dev/jsonapi/node/article?_format=api_json&filter%5Bcreated%5D%5Bvalue%5D=1469001416&filter%5Bcreated%5D%5Boperator%5D=%3D', res.url);
     });
 });
 
@@ -91,7 +91,7 @@ test('JSONAPI - Post', t => {
       t.deepEqual({
         method: 'POST',
         timeout: 500,
-        url: 'http://foo.dev/api/node/article?_format=api_json',
+        url: 'http://foo.dev/jsonapi/node/article?_format=api_json',
         headers:{
           Authorization: 'Bearer 123456',
           'Content-Type': 'application/vnd.api+json'
@@ -100,5 +100,16 @@ test('JSONAPI - Post', t => {
           some: 'data'
         }
       }, res);
+    });
+});
+
+test('JSONAPI - Prefix option', t => {
+  requireSubvert.subvert('axios', options => (
+    Promise.resolve({data: options})
+  ));
+  const jsonapi = new t.context.JSONAPI({...t.context.options, prefix: 'api'});
+  return jsonapi.get('node/article', {})
+    .then(res => {
+      t.is('http://foo.dev/api/node/article?_format=api_json', res.url);
     });
 });


### PR DESCRIPTION
Adds support for https://www.drupal.org/node/2838580.
Depending on the version of the JSONAPI module being used, a different prefix could be required. `api` for older versions and `jsonapi` for future versions (part of 1.x-dev). This option makes that configurable.

If you prefer eslint rules to remain the same thats 👍. 